### PR TITLE
Break default and internal configs apart

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,24 @@ This repository holds some standard configurations for [Renovate](https://www.me
 
 ## Behaviour
 
-### Internal
+### Default
 
-The internal config (`internal.json`) is intended for dxw internal repos where the impact of changes is low. It implements the following behaviours:
+The default config (`default.json`) is intended as a good starting point for any repository. It implements the following behaviours:
 
-- Will create a "Dependency Dashboard" issue for the repository, for tracking the state of updates and triggering some behaviours
-- Automatically merges minor and patch updates to all dependencies between 10am and 4pm
+- Creates a "Dependency Dashboard" issue for the repository, for tracking the state of updates and triggering some behaviours
+- Automatically merges patch updates to all dependencies between 10am and 4pm
+- Automatically merges updates from [linters](https://docs.renovatebot.com/presets-packages/#packageslinters) and [testing tools](https://docs.renovatebot.com/presets-packages/#packagestest). Note that the definitions for these packages are not exhaustive, so some linters and testers will still have PRs opened as normal.
 - Opens a PR for all updates, and requires all tests to pass
 - Requires all major updates to have a PR explicitly opened via the Dependency Dashboard
-- Will wait three days following a package release before opening PRs (to allow time for broken versions to be yanked)
-  - For NPM packages (which have a higher churn), will wait five days.
+- Waits three days following a package release before opening PRs (to allow time for broken versions to be yanked)
+  - For NPM packages (which have a higher churn), waits five days.
+
+### Internal
+
+The internal config (`internal.json`) is intended for dxw internal repos where the impact of changes is generally lower. In addition to the defaults, it implements the following behaviours:
+
+- Automatically merges minor updates, as well as patch
+- Combines patch updates and minor updates into a single pull request
 
 ## How to use
 
@@ -24,10 +32,17 @@ The internal config (`internal.json`) is intended for dxw internal repos where t
    ```json
    {
      "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+     "extends": ["github>dxw/renovate-config"]
+   }
+   ```
+   or, for most internal repositories:
+   ```json
+   {
+     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
      "extends": ["github>dxw/renovate-config:internal"]
    }
    ```
    If this is a new installation of Renovate then it will automatically open a new PR for this file.
-1. Change any other [configuration options](https://docs.renovatebot.com/configuration-options/) specific to the repository.
+1. Consider if these presets meet the needs of the repository. These are _not_ intended to be prescriptive, just a starting point. If you need to, change any other [configuration options](https://docs.renovatebot.com/configuration-options/) specific to the repository.
 1. If a new installation, merge the Renovate configuration PR.
-1. If you have branch protection turned on and it requires reviews, make sure you either [bypass protections for Renovate or install renovate-approve](https://docs.renovatebot.com/key-concepts/automerge/#pull-requests-required).
+1. If you have branch protection turned on and it requires reviews, make sure you either [bypass protections for Renovate or install renovate-approve](https://docs.renovatebot.com/key-concepts/automerge/#pull-requests-required). The recommended path is to use the bypass protections unless you need approvals for another workflow.

--- a/default.json
+++ b/default.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":approveMajorUpdates",
+    ":automergeLinters",
+    ":automergePatch",
+    ":automergePr",
+    ":automergeRequireAllStatusChecks",
+    ":automergeTesters",
+    ":dependencyDashboard",
+    ":enablePreCommit"
+  ],
+  "timezone": "Europe/London",
+  "platformAutomerge": true,
+  "automergeSchedule": ["after 10am every weekday", "before 4pm every weekday"],
+  "minimumReleaseAge": "3 days",
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "5 days"
+    }
+  ],
+  "labels": ["dependencies"]
+}

--- a/internal.json
+++ b/internal.json
@@ -1,26 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    ":approveMajorUpdates",
-    ":automergeLinters",
+    "github>dxw/renovate-config",
     ":automergeMinor",
-    ":automergePr",
-    ":automergeRequireAllStatusChecks",
-    ":automergeTesters",
-    ":dependencyDashboard",
-    ":enablePreCommit",
     ":combinePatchMinorReleases"
-  ],
-  "timezone": "Europe/London",
-  "platformAutomerge": true,
-  "automergeSchedule": ["after 10am every weekday", "before 4pm every weekday"],
-  "minimumReleaseAge": "3 days",
-  "packageRules": [
-    {
-      "matchDatasources": ["npm"],
-      "minimumReleaseAge": "5 days"
-    }
-  ],
-  "labels": ["dependencies"]
+  ]
 }


### PR DESCRIPTION
This creates a new `default.json` set of configurations which are a more conservative version of `internal.json`, and better suited for external projects. The internal configuration now inherits from this, and overrides as necessary to maintain its more optimistic outlook on minor version updates.