### PR TITLE
Add pre-commit to run sense checks on commits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,14 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.23.0
+    hooks:
+      - id: check-jsonschema
+        files: .json$
+        args:
+          - --schemafile=https://docs.renovatebot.com/renovate-schema.json
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
+        types_or: [yaml, json, markdown]

--- a/internal.json
+++ b/internal.json
@@ -14,10 +14,7 @@
   ],
   "timezone": "Europe/London",
   "platformAutomerge": true,
-  "automergeSchedule": [
-    "after 10am every weekday",
-    "before 4pm every weekday"
-  ],
+  "automergeSchedule": ["after 10am every weekday", "before 4pm every weekday"],
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
This adds a [pre-commit](https://pre-commit.com/) config which checks files to make sure they parse, are neatly formatted, and meet the necessary schema for a Renovate config file.

It also adds a new GitHub workflow which runs against pull requests, which lets us run these checks in CI.