### PR TITLE
Automatically open PRs for major updates on internal projects

### DIFF
--- a/internal.json
+++ b/internal.json
@@ -4,5 +4,11 @@
     "github>dxw/renovate-config",
     ":automergeMinor",
     ":combinePatchMinorReleases"
+  ],
+  "packageRules": [
+    {
+      "dependencyDashboardApproval": false,
+      "matchUpdateTypes": ["major"]
+    }
   ]
 }


### PR DESCRIPTION
Currently PRs major updates have to be manually triggered on the Renovate dashboard. This is a pain.

This change will get Renovate to create those PRs (but not merge them) automatically for internal projects.