### PR TITLE
Encourage following standard Rails upgrade process

### DIFF
--- a/default.json
+++ b/default.json
@@ -19,6 +19,14 @@
     {
       "matchDatasources": ["npm"],
       "minimumReleaseAge": "5 days"
+    },
+    {
+      "matchCategories": "ruby",
+      "matchDepNames": "rails",
+      "matchUpdateTypes": ["major", "minor"],
+      "prBodyNotes": [
+        ":warning: Remember to follow the [standard Rails upgrade process](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#the-upgrade-process)"
+      ]
     }
   ],
   "labels": ["dependencies"]

--- a/internal.json
+++ b/internal.json
@@ -9,6 +9,12 @@
     {
       "dependencyDashboardApproval": false,
       "matchUpdateTypes": ["major"]
+    },
+    {
+      "matchCategories": "ruby",
+      "matchDepNames": "rails",
+      "matchUpdateTypes": ["minor"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
It's recommended to follow the [standard upgrade process](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#the-upgrade-process) when bumping Rails by a minor or major version

This updates our Renovate config to:
- avoid automerging minor version bumps for Rails (only the internal config is changed, since our default config doesn't automerge minor bumps)
- provide a warning/reminder about following the process in PR bodies for matching upgrades

An example of an app that's missed changes because of automerging minor Rails upgrades: https://github.com/dxw/ruby-developer-worksim-template/pull/151 (see the second, third, and fourth commits)