### PR TITLE
Pin GitHub actions to digests

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
+    "helpers:pinGitHubActionDigests",
     ":approveMajorUpdates",
     ":automergeLinters",
     ":automergePatch",


### PR DESCRIPTION
In a recent well-publicised security incident/supply chain attack, malicious code was force pushed to certain tags of a GitHub action:
- https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
- https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066

Pinning GitHub Actions to digests avoids this vulnerability, since digests can't be overwritten (unlike tags)