### PR TITLE
Use best practices preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,15 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    "helpers:pinGitHubActionDigests",
+    "config:best-practices",
     ":approveMajorUpdates",
     ":automergeLinters",
     ":automergePatch",
     ":automergePr",
     ":automergeRequireAllStatusChecks",
     ":automergeTesters",
-    ":dependencyDashboard",
     ":enablePreCommit"
   ],
   "timezone": "Europe/London",


### PR DESCRIPTION
`config:base` became `config:recommended` some time ago: https://github.com/renovatebot/renovate/commit/f9e3e80e0c9c6a972d847f8740de5016a2bf698a. It looks like Renovate automatically translates the old name to the new one:
https://github.com/renovatebot/renovate/blob/f9e3e80e0c9c6a972d847f8740de5016a2bf698a/lib/config/presets/common.ts#L17

`config:best-practices` extends `config:recommended` but also adds the two presets removed here (pinning GitHub Action digests and using the dependency dashboard) as well as pinning Docker digests and keeping Renovate config up to date (e.g. changes in config naming as mentioned above). This all seems good an reasonable

Closes #39 