### PR TITLE
Swap check-jsonschema for Renovate's own validation hook

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,12 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
 
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.33.2
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 41.20.2
     hooks:
-      - id: check-jsonschema
-        files: .json$
-        args:
-          - --schemafile=https://docs.renovatebot.com/renovate-schema.json
+      - id: renovate-config-validator
+        args: [--strict]
+        files: .*\.json
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0


### PR DESCRIPTION
Renovate provide a [pre-commit hook](https://github.com/renovatebot/pre-commit-hooks) for validating configurations. We should make use of it, as it offers additional checks above a straight schema validation.